### PR TITLE
bump selenium versions and add firefox support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                                org.eclipse.jetty/jetty-util]]
                  [org.seleniumhq.selenium/selenium-firefox-driver "3.5.3"]
                  [environ "1.1.0"]
-                 [ring/ring-jetty-adapter "1.6.0-RC3"]]
+                 [ring/ring-jetty-adapter "1.6.2"]]
   :profiles
   {:dev {:source-paths ["dev"]
          :dependencies [[pjstadig/humane-test-output "0.8.2"]

--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,23 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.4.0"]
-                 [org.seleniumhq.selenium/selenium-support "3.4.0"]
-                 [org.seleniumhq.selenium/selenium-api "3.4.0"]
-                 [org.seleniumhq.selenium/selenium-server "3.4.0" :exclusions [org.seleniumhq.selenium/selenium-api org.seleniumhq.selenium/selenium-support]]
-                 [org.seleniumhq.selenium/selenium-java "3.4.0" :exclusions [org.seleniumhq.selenium/selenium-api org.seleniumhq.selenium/selenium-support]]
-                 [environ "1.1.0"]]
+                 [org.seleniumhq.selenium/selenium-support "3.5.3"]
+                 [org.seleniumhq.selenium/selenium-api "3.5.3"]
+                 [org.seleniumhq.selenium/selenium-server "3.5.3"
+                  :exclusions [org.seleniumhq.selenium/selenium-api
+                               org.seleniumhq.selenium/selenium-support
+                               org.eclipse.jetty/jetty-http
+                               org.eclipse.jetty/jetty-io
+                               org.eclipse.jetty/jetty-util]]
+                 [org.seleniumhq.selenium/selenium-java "3.5.3"
+                  :exclusions [org.seleniumhq.selenium/selenium-api
+                               org.seleniumhq.selenium/selenium-support
+                               org.eclipse.jetty/jetty-http
+                               org.eclipse.jetty/jetty-io
+                               org.eclipse.jetty/jetty-util]]
+                 [org.seleniumhq.selenium/selenium-firefox-driver "3.5.3"]
+                 [environ "1.1.0"]
+                 [ring/ring-jetty-adapter "1.6.0-RC3"]]
   :profiles
   {:dev {:source-paths ["dev"]
          :dependencies [[pjstadig/humane-test-output "0.8.2"]

--- a/src/limo/api.clj
+++ b/src/limo/api.clj
@@ -204,10 +204,13 @@
    (cond
      (string? selector-or-element)
      (execute-script driver
-                     (format "document.querySelector(\"%s\").scrollIntoViewIfNeeded();" selector-or-element))
+                     (if (= org.openqa.selenium.firefox.FirefoxDriver (type *driver*))
+                       (format "document.querySelector(\"%s\").scrollIntoView();" selector-or-element)
+                       (format "document.querySelector(\"%s\").scrollIntoViewIfNeeded();" selector-or-element)))
      (element? selector-or-element)
-     (execute-script driver
-                     "arguments[0].scrollIntoViewIfNeeded();"
+     (execute-script driver (if (= org.openqa.selenium.firefox.FirefoxDriver (type *driver*))
+                              "arguments[0].scrollIntoView();"
+                              "arguments[0].scrollIntoViewIfNeeded();")
                      selector-or-element))
    selector-or-element))
 

--- a/src/limo/driver.clj
+++ b/src/limo/driver.clj
@@ -13,6 +13,7 @@
            org.openqa.selenium.logging.LoggingPreferences
            org.openqa.selenium.WebDriver
            org.openqa.selenium.chrome.ChromeDriver
+           org.openqa.selenium.firefox.FirefoxDriver
            org.openqa.selenium.WebDriverException
            org.openqa.selenium.Dimension
            java.util.logging.Level
@@ -61,6 +62,7 @@
 
 (def capabilities
   {:chrome (DesiredCapabilities/chrome)
+   :firefox (DesiredCapabilities/firefox)
    :browser-stack {:samsung-galaxy-s4 (doto (DesiredCapabilities.)
                                         (logging-capability)
                                         (.setCapability "browserName" "android")
@@ -71,6 +73,10 @@
 (defn create-chrome
   ([] (create-chrome (:chrome capabilities)))
   ([capabilities] (ChromeDriver. capabilities)))
+
+(defn create-firefox
+  ([] (create-firefox (:firefox capabilities)))
+  ([capabilities] (FirefoxDriver. capabilities)))
 
 (defn create-remote
   ([desired-capabilities] (RemoteWebDriver. desired-capabilities))


### PR DESCRIPTION
Firefox webdriver via geckodriver and Firefox 55+ works wonderfully on my computer. Bumping the selenium drivers caused clashes with jetty, so I excluded them and added seperate ring-jetty dependency to minimize dependency conflicts.