### PR TITLE
bump selenium to v3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# limo
+# Limo [![CircleCI](https://circleci.com/gh/Mayvenn/limo/tree/master.svg?style=svg&circle-token=e216b48367b08611e35c36e8531bdaa93b349be6)](https://circleci.com/gh/Mayvenn/limo/tree/master)
 
 A Clojure library that's a small wrapper around selenium webdriver.
 
@@ -11,7 +11,6 @@ Limo embraces its tight coupling to Selenium Webdriver. That means no wrapper ty
 Add your `project.clj` file:
 
 [![Clojars Project](https://img.shields.io/clojars/v/limo.svg)](https://clojars.org/limo)
-[![CircleCI](https://circleci.com/gh/Mayvenn/limo/tree/master.svg?style=svg&circle-token=e216b48367b08611e35c36e8531bdaa93b349be6)](https://circleci.com/gh/Mayvenn/limo/tree/master)
 
 ## Basic Usage - functional test
 
@@ -53,7 +52,7 @@ Please see [limo-driver's README.md](https://github.com/agilecreativity/limo-dri
 
 ## License
 
-Copyright © 2016 Mayvenn
+Copyright © 2017 Mayvenn
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -1,25 +1,25 @@
-(defproject limo "0.1.9-SNAPSHOT"
+(defproject limo "0.1.10-SNAPSHOT"
   :description "A clojure wrapper around selenium webdriver"
   :url "https://github.com/mayvenn/limo"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.4.0"]
-                 [org.seleniumhq.selenium/selenium-support "3.5.3"]
-                 [org.seleniumhq.selenium/selenium-api "3.5.3"]
-                 [org.seleniumhq.selenium/selenium-server "3.5.3"
+                 [org.seleniumhq.selenium/selenium-support "3.6.0"]
+                 [org.seleniumhq.selenium/selenium-api "3.6.0"]
+                 [org.seleniumhq.selenium/selenium-server "3.6.0"
                   :exclusions [org.seleniumhq.selenium/selenium-api
                                org.seleniumhq.selenium/selenium-support
                                org.eclipse.jetty/jetty-http
                                org.eclipse.jetty/jetty-io
                                org.eclipse.jetty/jetty-util]]
-                 [org.seleniumhq.selenium/selenium-java "3.5.3"
+                 [org.seleniumhq.selenium/selenium-java "3.6.0"
                   :exclusions [org.seleniumhq.selenium/selenium-api
                                org.seleniumhq.selenium/selenium-support
                                org.eclipse.jetty/jetty-http
                                org.eclipse.jetty/jetty-io
                                org.eclipse.jetty/jetty-util]]
-                 [org.seleniumhq.selenium/selenium-firefox-driver "3.5.3"]
+                 [org.seleniumhq.selenium/selenium-firefox-driver "3.6.0"]
                  [environ "1.1.0"]
                  [ring/ring-jetty-adapter "1.6.2"]]
   :profiles


### PR DESCRIPTION
There's a fix in 3.6.0 for gaecko driver, 3.7.0 is already released. Haven't tried that, but I just noticed it as I made this pull request, will update this PR for 3.7.0 if everything works still.